### PR TITLE
Prefer online for npm install (and added versions command to run the post version command of all packages recursively)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
               while IFS="|" read -r pkg path; do
                 version=$(jq -r .version ${path#file:}/package.json)
                 echo "- Updating dependencies $pkg to ^$version (found in ${path#file:}/package.json)"
-                npm install $pkg@^$version
+                npm install $pkg@^$version --prefer-online
               done
             fi
 
@@ -72,7 +72,7 @@ jobs:
               while IFS="|" read -r pkg path; do
                 version=$(jq -r .version ${path#file:}/package.json)
                 echo "- Updating dev dependencies $pkg to ^$version (found in ${path#file:}/package.json)"
-                npm install $pkg@^$version --save-dev
+                npm install $pkg@^$version --save-dev --prefer-online
               done
             fi
             

--- a/base/package-lock.json
+++ b/base/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krmx/base",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krmx/base",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^29.5.1",

--- a/base/package.json
+++ b/base/package.json
@@ -2,7 +2,7 @@
   "name": "@krmx/base",
   "description": "krmx base",
   "author": "Simon Karman",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "dist/src/index.js",
   "scripts": {
     "test": "jest --coverage --silent --verbose",

--- a/base/src/version.ts
+++ b/base/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.6.2';
+export const VERSION = '0.6.3';

--- a/client-react/package-lock.json
+++ b/client-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krmx/client-react",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krmx/client-react",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "ISC",
       "dependencies": {
         "@krmx/base": "file:../base",
@@ -39,7 +39,7 @@
     },
     "../base": {
       "name": "@krmx/base",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^29.5.1",
@@ -57,7 +57,7 @@
     },
     "../client": {
       "name": "@krmx/client",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "ISC",
       "dependencies": {
         "@krmx/base": "file:../base"
@@ -80,7 +80,7 @@
     },
     "../server": {
       "name": "@krmx/server",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/client-react/package.json
+++ b/client-react/package.json
@@ -2,7 +2,7 @@
   "name": "@krmx/client-react",
   "description": "krmx client for react",
   "author": "Simon Karman",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "dist/src/index.js",
   "scripts": {
     "test": "jest --coverage --silent --verbose",

--- a/client-react/src/version.ts
+++ b/client-react/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.6.2';
+export const VERSION = '0.6.3';

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krmx/client",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krmx/client",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "ISC",
       "dependencies": {
         "@krmx/base": "file:../base"
@@ -29,7 +29,7 @@
     },
     "../base": {
       "name": "@krmx/base",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^29.5.1",
@@ -47,7 +47,7 @@
     },
     "../server": {
       "name": "@krmx/server",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "@krmx/client",
   "description": "krmx client",
   "author": "Simon Karman",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "dist/src/index.js",
   "scripts": {
     "test": "jest --coverage --silent --verbose",

--- a/client/src/version.ts
+++ b/client/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.6.2';
+export const VERSION = '0.6.3';

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dev:server": "sleep 250 && npm run --prefix server dev",
     "dev:client": "sleep 500 && npm run --prefix client dev",
     "dev:client-react": "sleep 750 && npm run --prefix client-react dev",
-    "dev:docs": "npm run --prefix docs dev"
+    "dev:docs": "npm run --prefix docs dev",
+    "versions": "npm --prefix base run postversion && npm --prefix server run postversion && npm --prefix client run postversion && npm --prefix client-react run postversion && npm --prefix state run versions"
   },
   "dependencies": {
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:client": "sleep 500 && npm run --prefix client dev",
     "dev:client-react": "sleep 750 && npm run --prefix client-react dev",
     "dev:docs": "npm run --prefix docs dev",
-    "versions": "npm --prefix base run postversion && npm --prefix server run postversion && npm --prefix client run postversion && npm --prefix client-react run postversion && npm --prefix state run versions"
+    "versions": "npm install && npm --prefix base run postversion && npm --prefix server run postversion && npm --prefix client run postversion && npm --prefix client-react run postversion && npm --prefix state run versions"
   },
   "dependencies": {
     "npm-run-all": "^4.1.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krmx/server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krmx/server",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "ISC",
       "dependencies": {
         "@krmx/base": "file:../base",
@@ -33,7 +33,7 @@
     },
     "../base": {
       "name": "@krmx/base",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^29.5.1",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@krmx/server",
   "description": "krmx server",
   "author": "Simon Karman",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "dist/src/index.js",
   "scripts": {
     "start": "nodemon --exec \"ts-node src/index.ts\" src/index.ts",

--- a/server/src/version.ts
+++ b/server/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.6.2';
+export const VERSION = '0.6.3';

--- a/state/package.json
+++ b/state/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "postinstall": "npm --prefix base install && npm --prefix server install && npm --prefix client-react install",
-    "validate": "npm run --prefix base validate && npm run --prefix server validate && npm run --prefix client-react validate"
+    "validate": "npm run --prefix base validate && npm run --prefix server validate && npm run --prefix client-react validate",
+    "versions": "npm --prefix base run postversion && npm --prefix server run postversion && npm --prefix client-react run postversion"
   },
   "devDependencies": {
     "husky": "^4.3.8"


### PR DESCRIPTION
By adding `--prefer-online` to npm install command, staleness checks for cached data will be forced, making the CLI look for updates immediately even for fresh package data. Hopefully this will resolve ETARGET failures when installing the recently published packages. More information: https://docs.npmjs.com/cli/v10/using-npm/config#prefer-online